### PR TITLE
Denumerator for MC and stitching weights

### DIFF
--- a/Corrections.py
+++ b/Corrections.py
@@ -96,3 +96,17 @@ def getWeights(df, config=None, sample=None):
     scale = 'Central'
     df = df.Define('weight', f'genWeightD * {lumi} * {stitching_weight_string} * puWeight_{scale}')
     return df, [ scale ]
+
+def getDenumerator(df, sources):
+    if not initialized:
+        raise RuntimeError('Corrections are not initialized')
+    df = pu.getWeight(df)
+    df = df.Define('genWeightD', 'std::copysign<double>(1., genWeight)')
+    syst_names =[]
+    for source in sources:
+        for scale in getScales(source):
+            syst_name = getSystName(source, scale)
+            pu_scale = scale if source == pu.uncSource else central
+            df = df.Define(f'weight_denum_{syst_name}', f'genWeightD * puWeight_{pu_scale}')
+            syst_names.append(syst_name)
+    return df,syst_names

--- a/Corrections.py
+++ b/Corrections.py
@@ -59,4 +59,16 @@ def applyScaleUncertainties(df):
                 if obj not in source_objs:
                     suffix = 'Central' if obj in [ "Tau", "MET" ] else 'nano'
                     df = df.Define(f'{obj}_p4_{syst_name}', f'{obj}_p4_{suffix}')
+    print(syst_dict)
     return df, syst_dict
+
+
+def getWeights(df):
+    if not initialized:
+        raise RuntimeError('Corrections are not initialized')
+    weight_dict = {}
+    df, weight_dict = tau.getESWeight(df, weight_dict)
+    df = df.Define('w_genWeightD', 'std::copysign<double>(1., genWeight)')
+    weight_dict.append('genWeightD')
+    print(weight_dict)
+    return df,weight_dict

--- a/CorrectionsCore.py
+++ b/CorrectionsCore.py
@@ -25,3 +25,7 @@ def updateSourceDict(source_dict, source, obj):
     if obj in source_dict[source]:
         raise RuntimeError(f"addUncSource: dupblicated {source} definition for {obj}")
     source_dict[source].append(obj)
+
+def updateWeightDict(weight_list, source):
+    if source not in weight_list:
+        weight_list.append('w_'+source)

--- a/corrections.h
+++ b/corrections.h
@@ -20,3 +20,17 @@ enum class UncScale : int {
 };
 
 }
+
+float GetStitchingWeight(const SampleType& sampleType, const float LHE_Vpt, const int LHE_Njets ){
+    if(sampleType==SampleType::DY)
+    {
+        if(LHE_Vpt==0.) return 1/2.;
+        else return 1/3.;
+    }
+    else if(sampleType==SampleType::W)
+    {
+        if(LHE_Njets>0) return 1/2.;
+        else return 1.;
+    }
+    return 1.;
+}

--- a/met.py
+++ b/met.py
@@ -29,3 +29,10 @@ class METCorrProducer:
                     df = df.Define(f'MET_p4_{syst_name}_delta', f'MET_p4_{syst_name} - MET_p4_{nano}')
 
         return df, source_dict_upd
+
+    '''
+    def getPFMETWeight(self, df, weight_list):
+        for source in [ central ] + TauCorrProducer.energyScaleSources:
+            updateWeightDict(weight_list, source)
+        return df, weight_list
+    '''

--- a/pu.h
+++ b/pu.h
@@ -1,0 +1,55 @@
+#pragma once
+#include "correction.h"
+#include "corrections.h"
+
+namespace correction {
+
+class puCorrProvider {
+public:
+
+    static void Initialize(const std::string& fileName)
+    {
+        _getGlobal() = std::make_unique<puCorrProvider>(fileName);
+    }
+
+    static const puCorrProvider& getGlobal()
+    {
+        const auto& corr = _getGlobal();
+        if(!corr)
+            throw std::runtime_error("puCorrProvider: not initialized.");
+        return *corr;
+    }
+
+    static const std::string& getScaleStr(UncScale scale)
+    {
+        static const std::map<UncScale, std::string> names = {
+            { UncScale::Down, "down" },
+            { UncScale::Central, "nominal" },
+            { UncScale::Up, "up" },
+        };
+        return names.at(scale);
+    }
+    puCorrProvider(const std::string& fileName) :
+        corrections_(CorrectionSet::from_file(fileName)),
+        puweight(corrections_->at("Collisions18_UltraLegacy_goldenJSON"))
+    {
+    }
+
+    float getWeight(UncScale scale, const float& Pileup_nTrueInt) const{
+        const std::string& scale_str = getScaleStr(scale);
+        const double w = puweight->evaluate({Pileup_nTrueInt, scale_str});
+
+        return w;
+    }
+private:
+    static std::unique_ptr<puCorrProvider>& _getGlobal()
+    {
+        static std::unique_ptr<puCorrProvider> corr;
+        return corr;
+    }
+    std::unique_ptr<CorrectionSet> corrections_;
+    Correction::Ref puweight;
+
+};
+
+} // namespace correction

--- a/pu.py
+++ b/pu.py
@@ -1,0 +1,22 @@
+import os
+import ROOT
+from .CorrectionsCore import *
+
+class puWeightProducer:
+    jsonPath = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/{}/puWeights.json.gz"
+    initialized = False
+
+    def __init__(self, period):
+        jsonFile = puWeightProducer.jsonPath.format(period)
+        if not puWeightProducer.initialized:
+            headers_dir = os.path.dirname(os.path.abspath(__file__))
+            header_path = os.path.join(headers_dir, "pu.h")
+            ROOT.gInterpreter.Declare(f'#include "{header_path}"')
+            ROOT.gInterpreter.ProcessLine(f'::correction::puCorrProvider::Initialize("{jsonFile}")')
+            puWeightProducer.initialized = True
+
+    def getWeight(self, df):
+        for scale in ['Central', 'Up', 'Down']:
+            df = df.Define(f'puWeight_{scale}', f'''::correction::puCorrProvider::getGlobal().getWeight(
+                            ::correction::UncScale::{scale}, Pileup_nTrueInt)''')
+        return df

--- a/pu.py
+++ b/pu.py
@@ -6,6 +6,8 @@ class puWeightProducer:
     jsonPath = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/{}/puWeights.json.gz"
     initialized = False
 
+    uncSource = 'pu'
+
     def __init__(self, period):
         jsonFile = puWeightProducer.jsonPath.format(period)
         if not puWeightProducer.initialized:

--- a/tau.py
+++ b/tau.py
@@ -30,3 +30,11 @@ class TauCorrProducer:
                 df = df.Define(f'Tau_p4_{syst_name}_delta', f'Tau_p4_{syst_name} - Tau_p4_{nano}')
 
         return df, source_dict
+
+
+    def getESWeight(self, df, weight_list):
+        for source in [ central ] + TauCorrProducer.energyScaleSources:
+            for scale in getScales(source):
+                syst_name = getSystName(source, scale)
+                updateWeightDict(weight_list, syst_name)
+        return df, weight_list


### PR DESCRIPTION
In this PR we want to implement the denumerator for the MC weight computation. It is done by:
- selecting both events selected and not selected
- creating a new branch that is genWeightD*pu_weight (for all variations) 

The stitching weights have been introduced too. The idea is that:
- for DY samples, if LHE_Vpt is 0, the stitching weight is 1/2 otherwise it's 1/3
- for W samples, if LHE_Njets==0 the stitching weight is 1 otherwise 1/2